### PR TITLE
iwlib/utils.h: Avoid leaking reference to object

### DIFF
--- a/iwlib/utils.h
+++ b/iwlib/utils.h
@@ -13,8 +13,10 @@
 #define SAFE_SETITEMSTRING(dict, key, value) do { \
     PyObject *__tmp; \
     __tmp = value; \
-    if (__tmp) \
+    if (__tmp) { \
         PyDict_SetItemString(dict, key, __tmp); \
+	Py_DECREF(__tmp); \
+    } \
 } while(0)
 
 


### PR DESCRIPTION
If we don't decrement the reference count of the object we insert into
the dictionary then we will leak the object later.

http://nedbatchelder.com/blog/200911/memory_leak_mystery.html