### PR TITLE
Fix wrong variable name

### DIFF
--- a/iwlib/iwconfig.py
+++ b/iwlib/iwconfig.py
@@ -41,8 +41,8 @@ def _get_iwconfig(interface, sock):
         return iwlib.iw_get_ext(sock, interface, flag, wrq) >= 0
 
     if not get_ext(iwlib.SIOCGIWNAME):
-        wrq.ifr_ifrn = interface[:iwlib.IFNAMSIZ-1]
-        wrq.ifr_ifrn[iwlib.IFNAMSIZ-1] = b'\0'
+        wrq.ifr_name = interface[:iwlib.IFNAMSIZ-1]
+        wrq.ifr_name[iwlib.IFNAMSIZ-1] = b'\0'
 
         if iwlib.ioctl(sock, iwlib.SIOCGIFFLAGS, wrq) < 0:
             err = errno.ENODEV


### PR DESCRIPTION
I got the following error saying `'struct iwreq *' has no field 'ifr_ifrn'`.
I found [a commit](https://github.com/nhoad/python-iwlib/commit/a7c14aff76a28004afb45e08bcf83be5948cb7c1#diff-7ed07be28984a7a0d7b9dcaef4777bdaR201) which changed the field name from `ifr_ifrn` to `ifr_name`, but the other corresponding variable names  were not changed accordingly.

```
>>> iwlib.get_iwconfig("wlan0")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/hitochan/.local/share/virtualenvs/wifi-location-3bXQYPoI/lib/python3.7/site-packages/iwlib/iwconfig.py", line 30, in get_iw
config
    return _get_iwconfig(interface, sock)
  File "/home/hitochan/.local/share/virtualenvs/wifi-location-3bXQYPoI/lib/python3.7/site-packages/iwlib/iwconfig.py", line 44, in _get_i
wconfig
    wrq.ifr_ifrn = interface[:iwlib.IFNAMSIZ-1]
AttributeError: cdata 'struct iwreq *' has no field 'ifr_ifrn'
```