### PR TITLE
Export scan method

### DIFF
--- a/iwlib/__init__.py
+++ b/iwlib/__init__.py
@@ -1,2 +1,4 @@
 # for backwards compatibility
 from .iwconfig import get_iwconfig
+
+from .iwlist import scan


### PR DESCRIPTION
I am not sure if I am doing the right thing but I am submitting this PR so that I can discuss the issue I am facing right now.
I understand that `scan` can be used to get info of all available APs but it is not imported in `__init__.py`.
So I import the method in the file so that I can import the method from the library.

~~I don't know why but `get_iwconfig` only returns the info of currently used AP, where I am supposed to get multiple results.
Do you have any idea of why this is happening?~~

```console
>>> iwlib.scan("wlan0")
[{'Mode': b'Master', 'ESSID': b'ESSID_HERE', 'Access Point': b'MAC_ADDRESS_HERE', 'BitRate': b'54 Mb/s', 'stats': {'quality': 47, 'level': 193, 'noise': 0, 'updated': 75}}]
```

~~I confirmed there are multiple APs (16) detected with `iw`.
Is this somehow related to sudo privilege?~~

```console
$ sudo iw wlan0 scan | grep "SSID:" | wc -l
16
```

**UPDATE: After I turned off and on WiFi, I am now able to get multiple APs.**
